### PR TITLE
[fix] Bug. Update server.ts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -162,7 +162,7 @@ export class CcxtMcpServer {
             const supportedTypes = {
               spot: exchangeInstance.has.spot,
               margin: exchangeInstance.has.margin,
-              future: exchangeInstance.has.futures,
+              future: exchangeInstance.has.future,
               swap: exchangeInstance.has.swap,
               option: exchangeInstance.has.option,
             };


### PR DESCRIPTION
[fix] Bug.
When using Binance usdm futures, the instance is not created, so I checked and found that has in describe is "future" instead of "futures". I modified the comparison part and committed it.


https://github.com/ccxt/ccxt/blob/master/js/src/binanceusdm.js
            'has': {
                'CORS': undefined,
                'spot': false,
                'margin': false,
                'swap': true,
                'future': true,
                'option': undefined,
                'createStopMarketOrder': true,
            },