### PR TITLE
Add Docker/Compose deployment with SSE auth and Nginx reverse proxy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,37 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm test
+
+  docker-validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build Docker image
+      run: docker build -t ccxt-mcp:ci .
+    - name: Validate docker compose config
+      run: |
+        cp config/ccxt-config.example.json config/ccxt-config.json
+        docker compose config
+    - name: Run container auth smoke test
+      run: |
+        cp config/ccxt-config.example.json config/ccxt-config.json
+        sed -i 's/REPLACE_WITH_A_LONG_RANDOM_TOKEN/CI_TEST_TOKEN_123/g' config/ccxt-config.json
+
+        docker compose up -d
+
+        for i in {1..20}; do
+          if curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer CI_TEST_TOKEN_123" http://127.0.0.1:2298/healthz | grep -q "200"; then
+            break
+          fi
+          sleep 1
+        done
+
+        NO_AUTH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:2298/healthz)
+        AUTH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer CI_TEST_TOKEN_123" http://127.0.0.1:2298/healthz)
+
+        test "$NO_AUTH_STATUS" = "401"
+        test "$AUTH_STATUS" = "200"
+    - name: Cleanup docker compose
+      if: always()
+      run: docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@
 .env.local
 .env*.local
 
+# 로컬 CCXT 계정 설정 (민감 정보)
+/config/*.json
+!/config/*.example.json
+
 # 테스트 결과
 /junit.xml
 /test-results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/bin ./bin
+
+# Default config path inside the container. Mount your config file to /config.
+ENTRYPOINT ["node", "dist/index.js"]
+CMD ["--config", "/config/ccxt-config.json"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -160,7 +160,7 @@ npx @lazydino/ccxt-mcp --help
 npx @lazydino/ccxt-mcp --config /path/to/ccxt-accounts.json
 ```
 
-저장소의 `examples/config-example.json`에서 예제 설정 파일을 찾을 수 있습니다.
+저장소의 `config/ccxt-config.example.json`에서 예제 설정 파일을 찾을 수 있습니다.
 
 > **별도 설정 파일을 사용하는 이유**:
 >

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This method includes CCXT account information directly in the Claude Desktop set
     "ccxt-mcp": {
       "command": "npx",
       "args": ["-y", "@lazydino/ccxt-mcp"],
+      "mcpBearerToken": "YOUR_MCP_TOKEN",
       "accounts": [
         {
           "name": "bybit_main",
@@ -108,10 +109,11 @@ Using this method, you don't need a separate configuration file. All settings ar
 
 To separate account information into a separate configuration file, set up as follows:
 
-1. **Create a Separate Configuration File** (e.g., `ccxt-accounts.json`):
+1. **Create a Separate Configuration File** (e.g., `ccxt-config.json`):
 
 ```json
 {
+  "mcpBearerToken": "YOUR_MCP_TOKEN",
   "accounts": [
     {
       "name": "bybit_main",
@@ -133,6 +135,8 @@ To separate account information into a separate configuration file, set up as fo
 
 > **Important**: The configuration file must contain an `accounts` array at the root level, as shown above.
 
+> **Important**: If you run the server in HTTP+SSE mode (`--sse`), set `mcpBearerToken` in the same config file. Clients must send `Authorization: Bearer <mcpBearerToken>` on requests.
+
 2. **Specify the Configuration File Path in Claude Desktop Settings**:
 
 ```json
@@ -144,7 +148,7 @@ To separate account information into a separate configuration file, set up as fo
         "-y",
         "@lazydino/ccxt-mcp",
         "--config",
-        "/path/to/ccxt-accounts.json"
+        "/path/to/ccxt-config.json"
       ]
     }
   }
@@ -157,10 +161,10 @@ To separate account information into a separate configuration file, set up as fo
 
 ```bash
 # Using custom configuration file
-npx @lazydino/ccxt-mcp --config /path/to/ccxt-accounts.json
+npx @lazydino/ccxt-mcp --config /path/to/ccxt-config.json
 ```
 
-You can find an example configuration file at `examples/config-example.json` in the repository.
+You can find an example configuration file at `config/ccxt-config.example.json` in the repository.
 
 > **Reasons to Use a Separate Configuration File**:
 >
@@ -295,6 +299,120 @@ npm install
 # Build
 npm run build
 ```
+
+## Docker
+
+### Build and Run with Docker Compose
+
+1. Create a config file:
+
+```bash
+cp config/ccxt-config.example.json config/ccxt-config.json
+```
+
+Then fill in your real API keys in `config/ccxt-config.json`.
+Also set `mcpBearerToken` in that same config file.
+2. Build image:
+
+```bash
+docker compose build
+```
+
+3. Start the MCP server in background (SSE mode on localhost:2298):
+
+```bash
+docker compose up -d
+```
+
+4. Verify local health endpoint:
+
+```bash
+curl -H "Authorization: Bearer YOUR_MCP_TOKEN" http://127.0.0.1:2298/healthz
+```
+
+This Compose setup runs MCP over HTTP+SSE (`/sse` + `/messages`) on localhost:2298 for reverse proxying.
+
+### Remote MCP Client Configuration
+
+If your MCP client runs on another host, use an Nginx reverse proxy on this machine.
+
+1. Copy `ccxt-mcp.nginx` to your Nginx config location and update certificate paths:
+
+```bash
+sudo cp ccxt-mcp.nginx /etc/nginx/conf.d/ccxt-mcp.conf
+```
+
+2. Edit `/etc/nginx/conf.d/ccxt-mcp.conf` and set:
+
+- `ssl_certificate`
+- `ssl_certificate_key`
+- Authorization header forwarding (already included in this file)
+
+3. Reload Nginx:
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+4. In your MCP client, configure the MCP server URL to your TLS endpoint:
+
+- SSE URL: `https://YOUR_HOSTNAME_OR_IP:42299/sse`
+- Messages URL: `https://YOUR_HOSTNAME_OR_IP:42299/messages`
+- Header: `Authorization: Bearer YOUR_MCP_TOKEN`
+
+You can generate a strong token with:
+
+```bash
+openssl rand -hex 32
+```
+
+Config example:
+
+```json
+{
+  "mcpBearerToken": "YOUR_MCP_TOKEN",
+  "accounts": [
+    {
+      "name": "bybit_main",
+      "exchangeId": "bybit",
+      "apiKey": "YOUR_API_KEY",
+      "secret": "YOUR_SECRET_KEY"
+    }
+  ]
+}
+```
+
+Port note:
+- `42298` is HTTP (redirect only)
+- `42299` is HTTPS
+- `2298` comes from `CCXT` on a phone keypad
+
+If your MCP client accepts command-based MCP servers instead of URL configuration, configure `ccxt-mcp` with:
+
+- Command: `docker`
+- Args:
+
+```json
+[
+  "run",
+  "--rm",
+  "-i",
+  "-p",
+  "127.0.0.1:2298:2298",
+  "-v",
+  "/absolute/path/to/ccxt-mcp/config/ccxt-config.json:/config/ccxt-config.json:ro",
+  "ccxt-mcp:local",
+  "--sse",
+  "--host",
+  "0.0.0.0",
+  "--port",
+  "2298",
+  "--config",
+  "/config/ccxt-config.json"
+]
+```
+
+Build the image first with `docker compose build`.
 
 ## 🤝 Contributing
 

--- a/ccxt-mcp.nginx
+++ b/ccxt-mcp.nginx
@@ -1,0 +1,53 @@
+# Ports (CCXT on phone keypad = 2298):
+#   HTTP  -> 42298 (redirects to HTTPS)
+#   HTTPS -> 42299
+server {
+    listen 42298;
+    listen [::]:42298;
+    server_name _;
+    return 301 https://$host:42299$request_uri;
+}
+
+server {
+    listen 42299 ssl;
+    listen [::]:42299 ssl;
+    http2 on;
+    server_name _;
+
+    # Replace with your host certificate and key paths.
+    ssl_certificate /etc/ssl/certs/your-host.crt;
+    ssl_certificate_key /etc/ssl/private/your-host.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # Require a bearer token header.
+    # Exact token validation is enforced by the app using mcpBearerToken from config.
+    # Authorization: Bearer <token>
+    set $mcp_token "";
+    if ($http_authorization ~* "^Bearer (.+)$") {
+        set $mcp_token $1;
+    }
+
+    if ($mcp_token = "") {
+        return 401 '{"jsonrpc":"2.0","error":{"code":-32600,"message":"Authorization: Bearer <token> required"},"id":null}';
+    }
+
+    # MCP SSE endpoint through local Docker backend.
+    location / {
+        proxy_pass http://127.0.0.1:2298;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding on;
+        proxy_read_timeout 300s;
+    }
+}

--- a/config/ccxt-config.example.json
+++ b/config/ccxt-config.example.json
@@ -1,4 +1,5 @@
 {
+  "mcpBearerToken": "REPLACE_WITH_A_LONG_RANDOM_TOKEN",
   "accounts": [
     {
       "name": "bybit_main",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  ccxt-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ccxt-mcp:local
+    ports:
+      - '127.0.0.1:2298:2298'
+    volumes:
+      - ./config/ccxt-config.json:/config/ccxt-config.json:ro
+    command:
+      [
+        "--sse",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "2298",
+        "--config",
+        "/config/ccxt-config.json"
+      ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,19 @@
  */
 
 import { CcxtMcpServer } from "./server.js";
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { URL } from "node:url";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 
 // 명령줄 인수 처리
 const args = process.argv.slice(2);
 let configPath = null;
+let useSse = false;
+let host = "127.0.0.1";
+let port = 2298;
 
 // --config 옵션 처리
 const configIndex = args.indexOf('--config');
@@ -16,10 +25,210 @@ if (configIndex !== -1 && args.length > configIndex + 1) {
   console.error(`[INFO] Using custom config file: ${configPath}`);
 }
 
+// --sse 옵션 처리
+if (args.includes('--sse')) {
+  useSse = true;
+}
+
+// --host 옵션 처리
+const hostIndex = args.indexOf('--host');
+if (hostIndex !== -1 && args.length > hostIndex + 1) {
+  host = args[hostIndex + 1];
+}
+
+// --port 옵션 처리
+const portIndex = args.indexOf('--port');
+if (portIndex !== -1 && args.length > portIndex + 1) {
+  const parsedPort = Number.parseInt(args[portIndex + 1], 10);
+  if (!Number.isNaN(parsedPort) && parsedPort > 0 && parsedPort <= 65535) {
+    port = parsedPort;
+  } else {
+    console.error(`[ERROR] Invalid --port value: ${args[portIndex + 1]}`);
+    process.exit(1);
+  }
+}
+
+const showHelp = args.includes('--help') || args.includes('-h');
+if (showHelp) {
+  console.error(`
+CCXT MCP Server
+
+Usage:
+  node dist/index.js [options]
+
+Options:
+  --config <path>   Path to config JSON file
+  --sse             Run as HTTP+SSE server for remote MCP clients
+  --host <host>     Host bind address for --sse mode (default: 127.0.0.1)
+  --port <port>     Port for --sse mode (default: 2298)
+  -h, --help        Show this help message
+`);
+  process.exit(0);
+}
+
+function resolveConfigPath(): string {
+  return (
+    configPath ||
+    path.join(os.homedir(), ".config", "Claude", "claude_desktop_config.json")
+  );
+}
+
+function readMcpBearerTokenFromConfig(configFilePath: string): string {
+  if (!fs.existsSync(configFilePath)) {
+    throw new Error(`Config file not found: ${configFilePath}`);
+  }
+
+  const raw = fs.readFileSync(configFilePath, "utf-8");
+  const parsed = JSON.parse(raw);
+
+  const tokenFromRoot =
+    typeof parsed?.mcpBearerToken === "string"
+      ? parsed.mcpBearerToken.trim()
+      : "";
+
+  if (tokenFromRoot) {
+    return tokenFromRoot;
+  }
+
+  const tokenFromMcpServer =
+    typeof parsed?.mcpServers?.["ccxt-mcp"]?.mcpBearerToken === "string"
+      ? parsed.mcpServers["ccxt-mcp"].mcpBearerToken.trim()
+      : "";
+
+  if (tokenFromMcpServer) {
+    return tokenFromMcpServer;
+  }
+
+  throw new Error(
+    `Missing required 'mcpBearerToken' in config file: ${configFilePath}`,
+  );
+}
+
+function readBearerTokenFromHeader(req: IncomingMessage): string | null {
+  const auth = req.headers.authorization;
+  if (!auth) return null;
+
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+
+  const token = match[1].trim();
+  return token || null;
+}
+
+async function startSseServer() {
+  const effectiveConfigPath = resolveConfigPath();
+  const expectedBearerToken = readMcpBearerTokenFromConfig(effectiveConfigPath);
+
+  const sessions = new Map<string, { transport: SSEServerTransport; mcpServer: CcxtMcpServer }>();
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const requestUrl = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+
+      const presentedBearerToken = readBearerTokenFromHeader(req);
+      if (!presentedBearerToken) {
+        res.writeHead(401, { "content-type": "application/json; charset=utf-8" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32600,
+              message: "Authorization: Bearer <token> required",
+            },
+            id: null,
+          }),
+        );
+        return;
+      }
+
+      if (presentedBearerToken !== expectedBearerToken) {
+        res.writeHead(403, { "content-type": "application/json; charset=utf-8" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32600,
+              message: "Invalid bearer token",
+            },
+            id: null,
+          }),
+        );
+        return;
+      }
+
+      if (req.method === "GET" && requestUrl.pathname === "/healthz") {
+        res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        res.end("ok");
+        return;
+      }
+
+      if (req.method === "GET" && requestUrl.pathname === "/sse") {
+        const mcpServer = new CcxtMcpServer(effectiveConfigPath);
+        const transport = new SSEServerTransport('/messages', res);
+
+        sessions.set(transport.sessionId, { transport, mcpServer });
+        res.on("close", async () => {
+          sessions.delete(transport.sessionId);
+          try {
+            await transport.close();
+          } catch {
+            // Ignore close errors during shutdown/connection teardown.
+          }
+        });
+
+        await mcpServer.connectTransport(transport);
+        return;
+      }
+
+      if (req.method === "POST" && requestUrl.pathname === "/messages") {
+        const sessionId = requestUrl.searchParams.get("sessionId");
+        if (!sessionId) {
+          res.writeHead(400, { "content-type": "text/plain; charset=utf-8" });
+          res.end("Missing sessionId query parameter");
+          return;
+        }
+
+        const session = sessions.get(sessionId);
+        if (!session) {
+          res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+          res.end("No active SSE transport for sessionId");
+          return;
+        }
+
+        await session.transport.handlePostMessage(req, res);
+        return;
+      }
+
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end("Not Found");
+    } catch (error) {
+      console.error("[ERROR] SSE request handling failed:", error);
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      }
+      res.end("Internal Server Error");
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(port, host, () => resolve());
+  });
+
+  console.error(`[INFO] CCXT MCP SSE server listening on http://${host}:${port}`);
+}
+
 // 서버 인스턴스 생성 및 시작
 console.error(`[INFO] Starting CCXT MCP Server...`);
-const server = new CcxtMcpServer(configPath);
-server.start().catch((error) => {
-  console.error("Failed to start server:", error);
-  process.exit(1);
-});
+if (useSse) {
+  startSseServer().catch((error) => {
+    console.error("Failed to start SSE server:", error);
+    process.exit(1);
+  });
+} else {
+  const server = new CcxtMcpServer(configPath || undefined);
+  server.start().catch((error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,8 @@ export class CcxtMcpServer {
   private publicExchangeInstances: Record<string, Exchange> = {};
   // 설정 파일 경로
   private configPath: string;
+  // 서버 초기화(계정 로드) 완료를 추적
+  private initPromise: Promise<void>;
 
   /**
    * @param configPath 사용자 지정 설정 파일 경로 (선택 사항)
@@ -92,7 +94,7 @@ export class CcxtMcpServer {
       );
 
     // 설정 파일에서 계정 로드 및 거래소 인스턴스 초기화
-    this.loadAccountsFromConfig();
+    this.initPromise = this.loadAccountsFromConfig();
 
     // 리소스 및 도구 등록
     this.registerResources();
@@ -414,6 +416,7 @@ export class CcxtMcpServer {
    * 서버를 시작합니다.
    */
   async start() {
+    await this.initPromise;
     const transport = new StdioServerTransport();
     await this.connectTransport(transport);
     console.error("CCXT MCP Server started");
@@ -423,6 +426,7 @@ export class CcxtMcpServer {
    * Connect the MCP server to any SDK transport (stdio, SSE, etc.).
    */
   async connectTransport(transport: Transport) {
+    await this.initPromise;
     await this.server.connect(transport);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import {
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js"; // Restore original path
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"; // Restore original path
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { URL } from "url";
 import { z } from "zod";
 import ccxt, { Exchange } from "ccxt"; // Import Exchange type
@@ -414,7 +415,14 @@ export class CcxtMcpServer {
    */
   async start() {
     const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    await this.connectTransport(transport);
     console.error("CCXT MCP Server started");
+  }
+
+  /**
+   * Connect the MCP server to any SDK transport (stdio, SSE, etc.).
+   */
+  async connectTransport(transport: Transport) {
+    await this.server.connect(transport);
   }
 }


### PR DESCRIPTION
## Summary
This PR adds a containerized deployment path for ccxt-mcp with secure remote access support.

## What changed
- Added a multi-stage Docker image build in .
- Added local deployment via .
- Added SSE runtime mode in  for remote MCP clients.
- Added app-level bearer auth enforcement in SSE mode using  from config.
- Added reusable transport connect path in  to support both stdio and SSE transports.
- Added Nginx reverse proxy config in  with:
  - HTTP -> HTTPS redirect ( -> )
  - bearer header requirement
  - proxying to localhost backend ()
- Updated docs in  for:
  - Docker + Compose usage
  - remote reverse-proxy usage
  - bearer token requirements
  - updated config file naming ()
- Added config example at .
- Removed legacy  and updated references.
- Added ignore rule for local config secrets in .

## Security notes
- Backend is bound to localhost only via compose ().
- Remote access is intended through Nginx with Authorization header checks.
- SSE mode requires  in config; stdio mode remains supported.

## Validation performed
- Built image successfully with 

```
#1 [internal] load local bake definitions
#1 reading from stdin 485B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile:
#2 transferring dockerfile: 523B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/node:20-alpine
#3 DONE 0.7s

#4 [internal] load .dockerignore
#4 transferring context: 2B done
#4 DONE 0.0s

#5 [internal] load build context
#5 DONE 0.0s

#6 [builder 1/6] FROM docker.io/library/node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c
#6 resolve docker.io/library/node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c 0.1s done
#6 DONE 0.1s

#5 [internal] load build context
#5 transferring context: 77.98kB done
#5 DONE 0.0s

#7 [builder 2/6] WORKDIR /app
#7 CACHED

#8 [builder 3/6] COPY package*.json ./
#8 CACHED

#9 [builder 4/6] RUN npm ci
#9 CACHED

#10 [builder 5/6] COPY . .
#10 DONE 0.3s

#11 [builder 6/6] RUN npm run build
#11 0.633 
#11 0.633 > @lazydino/ccxt-mcp@0.4.1 build
#11 0.633 > tsc
#11 0.633 
#11 DONE 5.8s

#12 [runner 4/6] RUN npm ci --omit=dev && npm cache clean --force
#12 CACHED

#13 [runner 5/6] COPY --from=builder /app/dist ./dist
#13 CACHED

#14 [runner 6/6] COPY --from=builder /app/bin ./bin
#14 CACHED

#15 exporting to image
#15 exporting layers done
#15 exporting manifest sha256:fd49465055cdacce0a9ea87666981dd43c00e279b968b86d8bbe8d2ae5a53df1 done
#15 exporting config sha256:a3b26725a88132e78c1f9f0053c4904645b6492bc7f9e3485bda50b2eb49e710 done
#15 exporting attestation manifest sha256:74664f9b302cef5f9f7766bb63f48341a1b9c7d7d9d72226510f6ea8c012419d 0.1s done
#15 exporting manifest list sha256:8d5d468710bdaafc919dc0223babdcfcce44c5d5b5e4ee31f000ee9a0729d6db
#15 exporting manifest list sha256:8d5d468710bdaafc919dc0223babdcfcce44c5d5b5e4ee31f000ee9a0729d6db 0.0s done
#15 naming to docker.io/library/ccxt-mcp:local done
#15 unpacking to docker.io/library/ccxt-mcp:local 0.0s done
#15 DONE 0.2s

#16 resolving provenance for metadata file
#16 DONE 0.0s.
```

- Verified backend auth behavior on localhost ( without token,  with valid token).
- Enabled Nginx site and verified proxied behavior on  ( without auth,  with auth).

## Backward compatibility
- Existing stdio flow remains available (no  required).
- Config loading for  remains intact.
